### PR TITLE
Allow url overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ client.login(secrets.email, secrets.password, (err, vehicle) => {
 
 ### Client
 
-> Client(regionCode, locale)
+> Client(regionCode, locale, urlOverride)
 
  - `regionCode` *(string, optional)*: The region in which the user resides. Defaults to `'NNA'` (United States). Use 'NE' to connect to the European endpoint.
  - `locale` *(string, optional)*: The locale (language) of the user. Defaults to `'en-US'` (English (United States)).
+ - `urlOverride` *(string, optional)*: The API endpoint to connect to. If `urlOverride` isn't specified the default API endpoint for the specified `regionCode` will be used.
  
 > login(email, password, callback)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ client.login(secrets.email, secrets.password, (err, vehicle) => {
 You can set the following fields on the options parameter:
  - `regionCode` *(string, optional)*: The region in which the user resides. Defaults to `'NNA'` (United States). Use 'NE' to connect to the European endpoint.
  - `locale` *(string, optional)*: The locale (language) of the user. Defaults to `'en-US'` (English (United States)).
- - `urlOverride` *(string, optional)*: The API endpoint to connect to. If `urlOverride` isn't specified the default API endpoint for the specified `regionCode` will be used.
+ - `baseEndpoint` *(string, optional)*: The API endpoint to connect to. If `baseEndpoint` isn't specified the default API endpoint for the specified `regionCode` will be used.
  
 > login(email, password, callback)
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ client.login(secrets.email, secrets.password, (err, vehicle) => {
 
 ### Client
 
-> Client(regionCode, locale, urlOverride)
+> Client(options)
+ - `options` *(object, optional)*: An options object you can use to configure the client's settings.
 
+You can set the following fields on the options parameter:
  - `regionCode` *(string, optional)*: The region in which the user resides. Defaults to `'NNA'` (United States). Use 'NE' to connect to the European endpoint.
  - `locale` *(string, optional)*: The locale (language) of the user. Defaults to `'en-US'` (English (United States)).
  - `urlOverride` *(string, optional)*: The API endpoint to connect to. If `urlOverride` isn't specified the default API endpoint for the specified `regionCode` will be used.

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -6,9 +6,9 @@ export class Api {
     private static NE_BASE_ENDPOINT = 'https://gdcportalgw.its-mo.com/api_v181217_NE/gdc';
     private static INITIAL_APP_STRINGS = 'geORNtsZe5I4lRGjG9GZiA';
 
-    private static getBaseEndpoint(regionCode: string, urlOverride?: string) {
-        if (typeof urlOverride !== 'undefined') {
-            return urlOverride;
+    private static getBaseEndpoint(regionCode: string, baseEndpoint?: string) {
+        if (typeof baseEndpoint !== 'undefined') {
+            return baseEndpoint;
         } else {
             return (regionCode === 'NNA' ? Api.NNA_BASE_ENDPOINT : Api.NE_BASE_ENDPOINT);
         }
@@ -17,10 +17,10 @@ export class Api {
     public static connect(
         regionCode: string,
         locale: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/InitialApp.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/InitialApp.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -48,13 +48,13 @@ export class Api {
         userId: string,
         password: string,
         passwordEncryptionKey: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
 
         const encryptedPassword = Api.encryptPassword(password, passwordEncryptionKey);
 
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/UserLoginRequest.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/UserLoginRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -86,10 +86,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/BatteryStatusCheckRequest.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/BatteryStatusCheckRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -124,10 +124,10 @@ export class Api {
         vin: string,
         timeZone: string,
         resultKey: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/BatteryStatusCheckResultRequest.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/BatteryStatusCheckResultRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -162,10 +162,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/BatteryStatusRecordsRequest.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/BatteryStatusRecordsRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -200,10 +200,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/RemoteACRecordsRequest.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/RemoteACRecordsRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -238,10 +238,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/ACRemoteRequest.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/ACRemoteRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -276,10 +276,10 @@ export class Api {
         vin: string,
         timeZone: string,
         resultKey: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/ACRemoteResult.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/ACRemoteResult.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -314,10 +314,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/ACRemoteOffRequest.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/ACRemoteOffRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -352,10 +352,10 @@ export class Api {
         vin: string,
         timeZone: string,
         resultKey: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/ACRemoteOffResult.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/ACRemoteOffResult.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -390,10 +390,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
-        urlOverride: string,
+        baseEndpoint: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/BatteryRemoteChargingRequest.php',
+            url: Api.getBaseEndpoint(regionCode, baseEndpoint) + '/BatteryRemoteChargingRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -7,7 +7,7 @@ export class Api {
     private static INITIAL_APP_STRINGS = 'geORNtsZe5I4lRGjG9GZiA';
 
     private static getBaseEndpoint(regionCode: string, baseEndpoint?: string) {
-        if (typeof baseEndpoint !== 'undefined') {
+        if (baseEndpoint) {
             return baseEndpoint;
         } else {
             return (regionCode === 'NNA' ? Api.NNA_BASE_ENDPOINT : Api.NE_BASE_ENDPOINT);

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -6,16 +6,21 @@ export class Api {
     private static NE_BASE_ENDPOINT = 'https://gdcportalgw.its-mo.com/api_v181217_NE/gdc';
     private static INITIAL_APP_STRINGS = 'geORNtsZe5I4lRGjG9GZiA';
 
-    private static getBaseEndpoint(regionCode: string) {
-        return (regionCode === 'NNA' ? Api.NNA_BASE_ENDPOINT : Api.NE_BASE_ENDPOINT);
+    private static getBaseEndpoint(regionCode: string, urlOverride?: string) {
+        if (typeof urlOverride !== 'undefined') {
+            return urlOverride;
+        } else {
+            return (regionCode === 'NNA' ? Api.NNA_BASE_ENDPOINT : Api.NE_BASE_ENDPOINT);
+        }
     }
 
     public static connect(
         regionCode: string,
         locale: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/InitialApp.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/InitialApp.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -43,12 +48,13 @@ export class Api {
         userId: string,
         password: string,
         passwordEncryptionKey: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
 
         const encryptedPassword = Api.encryptPassword(password, passwordEncryptionKey);
 
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/UserLoginRequest.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/UserLoginRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -80,9 +86,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/BatteryStatusCheckRequest.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/BatteryStatusCheckRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -117,9 +124,10 @@ export class Api {
         vin: string,
         timeZone: string,
         resultKey: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/BatteryStatusCheckResultRequest.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/BatteryStatusCheckResultRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -154,9 +162,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/BatteryStatusRecordsRequest.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/BatteryStatusRecordsRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -191,9 +200,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/RemoteACRecordsRequest.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/RemoteACRecordsRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -228,9 +238,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/ACRemoteRequest.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/ACRemoteRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -265,9 +276,10 @@ export class Api {
         vin: string,
         timeZone: string,
         resultKey: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/ACRemoteResult.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/ACRemoteResult.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -302,9 +314,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/ACRemoteOffRequest.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/ACRemoteOffRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -339,9 +352,10 @@ export class Api {
         vin: string,
         timeZone: string,
         resultKey: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/ACRemoteOffResult.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/ACRemoteOffResult.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,
@@ -376,9 +390,10 @@ export class Api {
         gdcUserId: string,
         vin: string,
         timeZone: string,
+        urlOverride: string,
         callback: (err?: Error, response?) => void): void {
         request.post({
-            url: Api.getBaseEndpoint(regionCode) + '/BatteryRemoteChargingRequest.php',
+            url: Api.getBaseEndpoint(regionCode, urlOverride) + '/BatteryRemoteChargingRequest.php',
             form: {
                 'initial_app_strings': Api.INITIAL_APP_STRINGS,
                 'RegionCode': regionCode,

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -3,7 +3,7 @@ import * as request from 'request';
 
 export class Api {
     private static NNA_BASE_ENDPOINT = 'https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc';
-    private static NE_BASE_ENDPOINT = 'https://gdcportalgw.its-mo.com/api_v180117_NE/gdc';
+    private static NE_BASE_ENDPOINT = 'https://gdcportalgw.its-mo.com/api_v181217_NE/gdc';
     private static INITIAL_APP_STRINGS = 'geORNtsZe5I4lRGjG9GZiA';
 
     private static getBaseEndpoint(regionCode: string) {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -10,15 +10,15 @@ export class Client {
     private _locale: string;
     private _regionCode: string;
     private _timeZone: string;
-    private _urlOverride: string;
+    private _baseEndpoint: string;
 
-    constructor(options?: {regionCode?: string, locale?: string, urlOverride?: string}) {
+    constructor(options?: {regionCode?: string, locale?: string, baseEndpoint?: string}) {
         if (typeof options === 'undefined') {
             options = {};
         }
         this._regionCode = options.regionCode || 'NNA'; // Default to North America
         this._locale = options.locale || 'en-US';       // Default to English (US)
-        this._urlOverride = options.urlOverride;        // Default to undefined
+        this._baseEndpoint = options.baseEndpoint;      // Default to undefined
     }
 
     public login(userId: string, password: string, callback: (err?: Error, vehicle?: IVehicle) => void): void {
@@ -36,7 +36,7 @@ export class Client {
                     userId,
                     password,
                     passwordEncryptionKey,
-                    that._urlOverride,
+                    that._baseEndpoint,
                     (err, response) => {
                         if (err) {
                             return callback(err);
@@ -77,7 +77,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
-            that._urlOverride,
+            that._baseEndpoint,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -98,7 +98,7 @@ export class Client {
                         vin,
                         that._timeZone,
                         resultKey,
-                        that._urlOverride,
+                        that._baseEndpoint,
                         (resultErr, resultResponse) => {
                             if (resultErr) {
                                 return callback(resultErr);
@@ -134,7 +134,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
-            that._urlOverride,
+            that._baseEndpoint,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -155,7 +155,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
-            that._urlOverride,
+            that._baseEndpoint,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -175,7 +175,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
-            that._urlOverride,
+            that._baseEndpoint,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -196,7 +196,7 @@ export class Client {
                         vin,
                         that._timeZone,
                         resultKey,
-                        that._urlOverride,
+                        that._baseEndpoint,
                         (resultErr, resultResponse) => {
                             if (resultErr) {
                                 return callback(resultErr);
@@ -232,7 +232,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
-            that._urlOverride,
+            that._baseEndpoint,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -253,7 +253,7 @@ export class Client {
                         vin,
                         that._timeZone,
                         resultKey,
-                        that._urlOverride,
+                        that._baseEndpoint,
                         (resultErr, resultResponse) => {
                             if (resultErr) {
                                 return callback(resultErr);
@@ -289,7 +289,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
-            that._urlOverride,
+            that._baseEndpoint,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -302,7 +302,7 @@ export class Client {
         Api.connect(
             this._regionCode,
             this._locale,
-            this._urlOverride,
+            this._baseEndpoint,
             (err, response) => {
                 if (err) {
                     return callback(err);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -10,10 +10,12 @@ export class Client {
     private _locale: string;
     private _regionCode: string;
     private _timeZone: string;
+    private _urlOverride: string;
 
-    constructor(regionCode?: string, locale?: string) {
+    constructor(regionCode?: string, locale?: string, urlOverride?: string) {
         this._regionCode = regionCode || 'NNA'; // Default to North America
         this._locale = locale || 'en-US';       // Default to English (US)
+        this._urlOverride = urlOverride;        // Default to undefined
     }
 
     public login(userId: string, password: string, callback: (err?: Error, vehicle?: IVehicle) => void): void {
@@ -31,6 +33,7 @@ export class Client {
                     userId,
                     password,
                     passwordEncryptionKey,
+                    that._urlOverride,
                     (err, response) => {
                         if (err) {
                             return callback(err);
@@ -71,6 +74,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
+            that._urlOverride,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -91,6 +95,7 @@ export class Client {
                         vin,
                         that._timeZone,
                         resultKey,
+                        that._urlOverride,
                         (resultErr, resultResponse) => {
                             if (resultErr) {
                                 return callback(resultErr);
@@ -126,6 +131,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
+            that._urlOverride,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -146,6 +152,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
+            that._urlOverride,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -165,6 +172,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
+            that._urlOverride,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -185,6 +193,7 @@ export class Client {
                         vin,
                         that._timeZone,
                         resultKey,
+                        that._urlOverride,
                         (resultErr, resultResponse) => {
                             if (resultErr) {
                                 return callback(resultErr);
@@ -220,6 +229,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
+            that._urlOverride,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -240,6 +250,7 @@ export class Client {
                         vin,
                         that._timeZone,
                         resultKey,
+                        that._urlOverride,
                         (resultErr, resultResponse) => {
                             if (resultErr) {
                                 return callback(resultErr);
@@ -275,6 +286,7 @@ export class Client {
             that._gdcUserId,
             vin,
             that._timeZone,
+            that._urlOverride,
             (err, response) => {
                 if (err) {
                     return callback(err);
@@ -287,6 +299,7 @@ export class Client {
         Api.connect(
             this._regionCode,
             this._locale,
+            this._urlOverride,
             (err, response) => {
                 if (err) {
                     return callback(err);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -12,10 +12,13 @@ export class Client {
     private _timeZone: string;
     private _urlOverride: string;
 
-    constructor(regionCode?: string, locale?: string, urlOverride?: string) {
-        this._regionCode = regionCode || 'NNA'; // Default to North America
-        this._locale = locale || 'en-US';       // Default to English (US)
-        this._urlOverride = urlOverride;        // Default to undefined
+    constructor(options?: {regionCode?: string, locale?: string, urlOverride?: string}) {
+        if (typeof options === 'undefined') {
+            options = {};
+        }
+        this._regionCode = options.regionCode || 'NNA'; // Default to North America
+        this._locale = options.locale || 'en-US';       // Default to English (US)
+        this._urlOverride = options.urlOverride;        // Default to undefined
     }
 
     public login(userId: string, password: string, callback: (err?: Error, vehicle?: IVehicle) => void): void {


### PR DESCRIPTION
Given that Nissan recently broke the library by removing the old URL and replacing it with a new one, I've added the capability for the caller to specify a custom URL. That means they don't have to wait for a rebuild of the package every time the endpoint URL changes.

The current PR tries to minimise the amount of refactoring to Api.ts. However, it does make the Client constructor a little ugly. Specifically, to set a custom URL you'd have to also set the optional locale attribute.

An alternative would be to have more constructors, such as:

- Client(regionCode, locale)
- Client(regionCode, urlOverride)
- Client(regionCode, locale, urlOverride)

but that may be overkill.

It's one of the limitations of TypeScript that optional parameters can't be referenced by name.

Let me know what you think. I'm happy to refactor the changes if you have suggestions for making it a little tidier. The code is tested with the EU carwings service.